### PR TITLE
Tile update

### DIFF
--- a/src/components/Tile/Tile.module.scss
+++ b/src/components/Tile/Tile.module.scss
@@ -24,29 +24,6 @@
     transition: var(--transitionLinear);
   }
 
-  .circular {
-    position: relative;
-    border-radius: 50%;
-    overflow: hidden;
-
-    img {
-      position: absolute;
-      top: 0;
-      left: 0;
-    }
-
-    &::before {
-      position: relative;
-      content: "";
-      display: block;
-      padding-top: 100%;
-    }
-  }
-
-  .rounded {
-    border-radius: 10px;
-  }
-
   .shadowed {
     box-shadow: 0px 5px 15px 0px rgba(0, 0, 0, 0.2);
   }
@@ -62,6 +39,29 @@
       text-decoration: underline;
       color: var(--bjsRedHover);
     }
+  }
+}
+
+.rounded {
+  border-radius: 10px;
+}
+
+.circular {
+  position: relative;
+  border-radius: 50%;
+  overflow: hidden;
+
+  img {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+
+  &::before {
+    position: relative;
+    content: "";
+    display: block;
+    padding-top: 100%;
   }
 }
 

--- a/src/components/Tile/Tile.module.scss
+++ b/src/components/Tile/Tile.module.scss
@@ -44,6 +44,11 @@
 
 .rounded {
   border-radius: 10px;
+  overflow: hidden;
+  > div {
+    border-radius: inherit;
+    overflow: inherit;
+  }
 }
 
 .circular {

--- a/src/components/Tile/Tile.tsx
+++ b/src/components/Tile/Tile.tsx
@@ -50,6 +50,12 @@ export function Tile({
     image.icon = variant === "Icon";
   }
 
+  const textAlign = () => {
+    return `text-${
+      textAlignment ? `${textAlignment.toLowerCase()}` : "center"
+    }`;
+  };
+
   const imageContainer = () => {
     return image ? (
       <div
@@ -65,7 +71,13 @@ export function Tile({
   };
 
   const titleOutput = () => {
-    return title && <h3 className="font-weight-bold mx-auto pt-3">{title}</h3>;
+    return (
+      title && (
+        <h3 className={`font-weight-bold ${textAlign()} mx-auto pt-3`}>
+          {title}
+        </h3>
+      )
+    );
   };
 
   const ctaOutput = () => {
@@ -77,7 +89,7 @@ export function Tile({
     ctaNode?: React.ReactNode
   ) => {
     return (
-      <div className={`${styles["tile-text-cont"]} col-12 py-3`}>
+      <div className={`${styles["tile-text-cont"]} ${textAlign()} col-12 py-3`}>
         {titleNode}
         {content && (
           <div dangerouslySetInnerHTML={{ __html: content.value }}></div>
@@ -97,8 +109,8 @@ export function Tile({
               className={`d-flex flex-wrap text-decoration-none mt-2 ${styles.tile}`}
             >
               {imageContainer()}
-              <div className="col-12">{titleOutput()}</div>
-              <div className="col-12">{ctaOutput()}</div>
+              <div className={`col-12 ${textAlign()}`}>{titleOutput()}</div>
+              <div className={`col-12 ${textAlign()}`}>{ctaOutput()}</div>
             </Link>
             {textContainer()}
           </>
@@ -122,13 +134,5 @@ export function Tile({
       </>
     );
   };
-  return (
-    <Container
-      className={`text-${
-        textAlignment ? `${textAlignment.toLowerCase()}` : "center"
-      }`}
-    >
-      {tileOutput()}
-    </Container>
-  );
+  return <Container>{tileOutput()}</Container>;
 }


### PR DESCRIPTION
Some additional updates to the tile component

 - Updated rounded edges to apply to inner icon as well, so icon edges can be rounded
 - Updated text align to apply to text only as opposed to entire container to avoid img from being other than center aligned (an issue when icon was selected, but not anymore)
 - Updated scss style hierarchy to ensure proper application and overriding of prior styles where required (namely for circular overriding rounded option, and for both being able to be applied) 